### PR TITLE
fix(scene): preserve addOptions merge and validate pageSize

### DIFF
--- a/src/lib/BaseService.ts
+++ b/src/lib/BaseService.ts
@@ -140,20 +140,21 @@ export class BaseService {
     this.ensureOptionsConfigured();
     try {
       const options = this.getOptions;
+      const { addOptions, ...dataWithoutAddOptions } = data;
       const addOptionsOverride =
-        typeof data.addOptions === "object" && data.addOptions !== null
-          ? (data.addOptions as Record<string, unknown>)
+        typeof addOptions === "object" && addOptions !== null
+          ? (addOptions as Record<string, unknown>)
           : {};
 
       const response = await this.http["post"]<T>(endpoint, {
         rootFolderPath: options.rootFolderPath,
         qualityProfileId: options.qualityProfile,
         tags: options.tags,
+        ...dataWithoutAddOptions,
         addOptions: {
           searchForMovie: options.searchOnAdd,
           ...addOptionsOverride,
         },
-        ...data,
       });
       return response.data;
     } catch (error) {

--- a/src/lib/SceneService.ts
+++ b/src/lib/SceneService.ts
@@ -36,6 +36,10 @@ export class SceneService {
    * @returns A fully shaped request body for /movie/paged.
    */
   private buildPagedPayload(params: ScenePagedQuery = {}): ScenePagedRequest {
+    if (params.pageSize !== undefined && params.pageSize <= 0) {
+      throw new Error("pageSize must be greater than 0.");
+    }
+
     return {
       page: params.page ?? 1,
       pageSize: params.pageSize ?? 25,


### PR DESCRIPTION
Prevent call-level addOptions from being overwritten in BaseService.add and reject non-positive pageSize values in SceneService paging payloads.