### PR TITLE
fix(ci): disable prerelease mode in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,9 +5,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "draft": false,
-      "prerelease": true,
-      "prerelease-type": "alpha"
+      "draft": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Remove prerelease alpha settings so releases are cut as stable semver versions.